### PR TITLE
Fixed typo

### DIFF
--- a/lib/voto_ruby/rest/client/interactions.rb
+++ b/lib/voto_ruby/rest/client/interactions.rb
@@ -1,12 +1,12 @@
 module VotoMobile
   module Interactions
     def interactions(full_path = nil)
-      list = InteractionList.new(self, 'interactions')
+      list = InteractionsList.new(self, 'interactions')
       get_data(list, 'interactions', full_path)
     end
 
     def interactions_by_tree_block(tree_id, block_id, filters={})
-      list = InteractionList.new self, 'interactions'
+      list = InteractionsList.new self, 'interactions'
       data = get("trees/#{tree_id}/blocks/#{block_id}/interactions", filters)
       try_paginate(data, list)
       list.assign_data(data['data']['interactions'])
@@ -14,7 +14,7 @@ module VotoMobile
     end
   end
 
-  class InteractionList < BaseList
+  class InteractionsList < BaseList
     ENTITY = Interaction
   end
 end

--- a/spec/rest/client/interaction_spec.rb
+++ b/spec/rest/client/interaction_spec.rb
@@ -7,7 +7,7 @@ describe VotoMobile::Interaction do
     stub_voto_request('trees/10/blocks/228/interactions', 'interactions')
 
     data = client.interactions_by_tree_block(10, 228)
-    expect(data).to be_a VotoMobile::InteractionList
+    expect(data).to be_a VotoMobile::InteractionsList
     expect(data.list[0]).to be_a VotoMobile::Interaction
     expect(data.list.length).to eq 5
   end


### PR DESCRIPTION
All ```ClassNameList``` in gem have ClassName word ending with 's'. The only exception was InteractonList.