### PR TITLE
Removed unnecessary method from tree blocks

### DIFF
--- a/lib/voto_ruby/rest/client/tree_blocks.rb
+++ b/lib/voto_ruby/rest/client/tree_blocks.rb
@@ -4,21 +4,12 @@ module VotoMobile
       list = TreeBlocksList.new self, 'blocks'
       data = get("trees/#{tree_id}/blocks")
       try_paginate(data, list)
-      list.assign_data(data['data']['blocks'], tree_id)
+      list.assign_data(data['data']['blocks'])
       list
     end
   end
 
   class TreeBlocksList < BaseList
     ENTITY = TreeBlock
-
-    def assign_data(list, tree_id)
-      unless list.length > 0
-        @data = []
-        return
-      end
-
-      @data = list.map { |hash| self.class::ENTITY.new(hash.merge(tree_id: tree_id), @client) }
-    end
   end
 end


### PR DESCRIPTION
Method is unnecessary because BaseList implements ```assign_data``` in correct way, no need for this override. Also, ```tree_id``` is stored in TreeBlock json itself, so no need to inject it here.